### PR TITLE
Add list search

### DIFF
--- a/app/controllers/api/v1/contents_controller.rb
+++ b/app/controllers/api/v1/contents_controller.rb
@@ -3,11 +3,22 @@ class Api::V1::ContentsController < ApplicationController
 
   def index
     @json = []
-    contents = Content.all
+    date = get_season
+    contents = Content.where('infoJSON LIKE?', "%#{date}%")
     contents.each do |f|
       @json << JSON.parse(f.infoJSON)
     end
     render status: 200, json: @json, message: "リスト読込完了"
+  end
+
+  def search_index
+    date = "#{params[:year]}" + "#{params[:season]}"
+    @search_json = []
+    contents = Content.where('infoJSON LIKE?', "%#{date}%")
+    contents.each do |f|
+      @search_json << JSON.parse(f.infoJSON)
+    end
+    render status: 200, json: @search_json, message: "リスト読込完了"
   end
 
   def show
@@ -48,6 +59,21 @@ class Api::V1::ContentsController < ApplicationController
   end
 
   private
+
+  def get_season
+     year = Date.current.strftime('%Y')
+     month = Date.current.strftime('%m').to_i
+     if month >= 1 && month < 4
+      season = '-winter'
+     elsif month >= 4 && month < 7
+      season = '-spring'
+     elsif month >= 7 && month < 10
+      season = '-summer'
+     else
+      season = '-autumn'
+     end
+     year + season
+  end
 
   def addList_params
     params.permit(:infoJSON, :title_id, :content)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       post '/search', to: 'contents#search', defaults: { format: :json }
+      post '/search_index', to: 'contents#search_index', defaults: { format: :json }
       resources :contents, only: [:index, :create, :destroy, :update, :show]
       mount_devise_token_auth_for 'User', at: 'auth'
     end

--- a/spec/controllers/contents_spec.rb
+++ b/spec/controllers/contents_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Api::V1::ContentsController do
       # infoJSON: "{\"id\":1, \"title\": \"test\"}"を送り変換されているかのテスト
       content = create(:content)
       get :index
-      expect(JSON.parse(response.body)[0].length).to eq 2
+      expect(JSON.parse(response.body)[0].length).to eq 3
     end
   end
 
@@ -43,7 +43,7 @@ RSpec.describe Api::V1::ContentsController do
     
     before do
       WebMock.enable!
-      WebMock.stub_request(:get, ENV["API_URL"] + "?filter_season&filter_title&per_page=4").
+      WebMock.stub_request(:get, ENV["API_URL"] + "?filter_season&filter_title&page&per_page").
         with(
           headers: { Authorization: ENV["API_KEY"] },
         ).

--- a/spec/factories/contents.rb
+++ b/spec/factories/contents.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :content do
     comment { "test" }
-    infoJSON { "{\"id\":1, \"title\": \"test\"}" }
+    infoJSON { "{\"id\":1, \"title\": \"test\", \"released_on\":\"2022-winter\"}" }
     sequence(:title_id) { |n| n }
   end
 end

--- a/spec/requests/contents_spec.rb
+++ b/spec/requests/contents_spec.rb
@@ -11,6 +11,13 @@ RSpec.describe "Content", type: :request do
       end
     end
 
+    context "search_indexに正常にリクエストを送った時" do
+      it "status200が返ってくる" do
+        post api_v1_search_index_path
+        expect(response.status).to eq 200
+      end
+    end
+
     context "createに正常にリクエストを送った時" do
       it "status200が返ってくる" do
         post api_v1_contents_path


### PR DESCRIPTION
シーズン毎のリストを検索できる様なアクションを追加。
2021-winter等で検索をかけてリストアップできます。
search_indexのテスト追加。一部項目変更によるテストのデータと内容の変更も行いました。